### PR TITLE
Update TNO_law_ideas_l_english.yml

### DIFF
--- a/localisation/TNO_law_ideas_l_english.yml
+++ b/localisation/TNO_law_ideas_l_english.yml
@@ -248,9 +248,9 @@
  tno_academic_base_d:0 "우리들의 연구 기반을 이루는 우리 주민의 평균 교육 수준입니다."
  tno_academic_base_mass_illiteracy:0 "문맹 다수"
  tno_academic_base_basic_literacy:0 "기본적 문해"
- tno_academic_base_primary_schooling:0 "초등학교 졸업"
- tno_academic_base_secondary_schooling:0 "중학교 졸업"
- tno_academic_base_tertiary_schooling:0 "고등학교 졸업"
+ tno_academic_base_primary_schooling:0 "초등교육 수료"
+ tno_academic_base_secondary_schooling:0 "중등교육 수료"
+ tno_academic_base_tertiary_schooling:0 "고등교육 수료"
  tno_academic_base_golden_age:0 "학문의 황금기"
 
  tno_research_facilities:0 "연구 시설"


### PR DESCRIPTION
고등학교 졸업 아이콘이 학사모인 걸 보면 중학교 졸업을 중등교육(중학교+고등학교), 고등학교 졸업을 고등교육(대학교) 수료로 바꾸는 게 적절할듯